### PR TITLE
Add support to upload data to strava instead of Garmin Connect

### DIFF
--- a/antd/antd.cfg
+++ b/antd/antd.cfg
@@ -37,15 +37,23 @@ tcx_output_dir = ~/.antd/%%(device_id)s/tcx
 cache = ~/.antd/raw-to-tcx-queue.txt
 
 [antd.connect]
-; true to enable upload to garmin connect
-; make sure to fill in username / password
+; true to enable uploading in general
 enabled = False
+; type of service (supported types: garmin, strava)
+type = garmin
 ; Garmin Connect username / password
+; Email smtp login info for strava
+garmin_username = 
+garmin_password = 
+; smtp server for uploading to strava
+smtp_server = smtp.gmail.com
+smtp_port = 587
+smtp_username =
+smtp_password =
 ; Note that you can put this section in 
 ; ~/.antd/antd.cfg if you don't
 ; want username / password in your git tree
-username = 
-password = 
+;
 ; file used to keep track of all tcx which
 ; are pending upload. files in the cache
 ; will have upload re-attempted until successful

--- a/antd/cfg.py
+++ b/antd/cfg.py
@@ -120,12 +120,20 @@ def create_antfs_host():
     host.transport_timeout = int(_cfg.get("antd.antfs", "transport_timeout"), 0)
     return host
 
-def create_garmin_connect_plugin():
+def create_upload_plugin():
     if _cfg.getboolean("antd.connect", "enabled"):
         import antd.connect as connect
-        client = connect.GarminConnect()
-        client.username = _cfg.get("antd.connect", "username")
-        client.password = _cfg.get("antd.connect", "password")
+        type = _cfg.get("antd.connect", "type")
+        if type == "garmin":
+            client = connect.GarminConnect()
+            client.username = _cfg.get("antd.connect", "garmin_username")
+            client.password = _cfg.get("antd.connect", "garmin_password")
+        elif type == "strava":
+            client = connect.StravaConnect()
+            client.smtp_server = _cfg.get("antd.connect", "smtp_server")
+            client.smtp_port = _cfg.get("antd.connect", "smtp_port")
+            client.smtp_username = _cfg.get("antd.connect", "smtp_username")
+            client.smtp_password = _cfg.get("antd.connect", "smtp_password")
         try:
             client.cache = os.path.expanduser(_cfg.get("antd.connect", "cache")) 
         except ConfigParser.NoOptionError: pass

--- a/antd/main.py
+++ b/antd/main.py
@@ -65,7 +65,7 @@ def downloader():
     
     # register plugins, add uploaders and file converters here
     antd.plugin.register_plugins(
-        antd.cfg.create_garmin_connect_plugin(),
+        antd.cfg.create_upload_plugin(),
         antd.cfg.create_tcx_plugin()
     )
     


### PR DESCRIPTION
Strava provides an email interface for all users to upload their files via upload@strava.com.  This can be hooked up to a basic gmail account or anything else with SMTP.  I tested it using Gmail with no troubles.
