### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ Make sure you have permission to access the USB device. Add a text file with one
 
 On Ubuntu 10.04 (or other other older distros):
 
-    SUBSYSTEM=="usb", SYSFS{idVendor}=="0fcf", SYSFS{idProduct}=="1008", MODE="666"
+    SUBSYSTEM=="usb", SYSFS{idVendor}=="0fcf", SYSFS{idProduct}=="1008", MODE:="666"
 
 On Ubuntu 12.04, Fedora 19 (or other distros running newer udev):
 
-    SUBSYSTEM=="usb", ATTR{idVendor}=="0fcf", ATTR{idProduct}=="1008", MODE="666"
+    SUBSYSTEM=="usb", ATTR{idVendor}=="0fcf", ATTR{idProduct}=="1008", MODE:="666"
 
 The first time you run the program it will need to pair with your GPS device. Make sure the the GPS unit is awake (press a button), and make sure pairing is enabled. Then just run <code>ant-downloader</code>. When prompted accept the pairing request on your GPS device. Once request is accepted a key is saved and you should not need to pair again.
 


### PR DESCRIPTION
Added ":" after mode as that is the correct syntax for adding permission rule in linux. Fond the bug after trying to get python-ant-downloader to work.