### PR TITLE
Support to use gupload to upload to Garmin Connect

### DIFF
--- a/antd/antd.cfg
+++ b/antd/antd.cfg
@@ -48,6 +48,14 @@ password =
 ; or until cache is deleted.
 cache = ~/.antd/garmin-connect-upload-queue.txt
 
+[antd.gupload]
+; Use garmin-uploader avaliable at https://github.com/La0/garmin-uploader to upload to Garmin Connect
+; garmin-uploader must be installed on the system and avaliable as gupload command in the shell
+enabled	= False
+username=
+password=
+cache = ~/.antd/gupload-upload-queue.txt
+
 [antd.strava]
 enabled = False
 ; smtp server for uploading to strava

--- a/antd/cfg.py
+++ b/antd/cfg.py
@@ -136,6 +136,17 @@ def create_garmin_connect_plugin():
             return client 
     except ConfigParser.NoSectionError: pass
 
+def create_gupload_plugin():
+    try:
+        if _cfg.getboolean("antd.gupload", "enabled"):
+            import antd.connect as connect
+            client = connect.GUpload()
+            client.username = _cfg.get("antd.gupload", "username")
+            client.password = _cfg.get("antd.gupload", "password")
+            client.cache = os.path.expanduser(_cfg.get("antd.gupload", "cache")) 
+            return client 
+    except ConfigParser.NoSectionError: pass
+
 def create_strava_plugin():
     try:
         if _cfg.getboolean("antd.strava", "enabled"):

--- a/antd/main.py
+++ b/antd/main.py
@@ -66,6 +66,7 @@ def downloader():
     antd.plugin.register_plugins(
         antd.cfg.create_garmin_connect_plugin(),
         antd.cfg.create_strava_plugin(),
+        antd.cfg.create_gupload_plugin(),
         antd.cfg.create_tcx_plugin(),
         antd.cfg.create_notification_plugin()
     )


### PR DESCRIPTION
Current Garmin Connect uploader doesn't work.
This is a quick fix to make it work again. 
It adds support to use the shell command gupload from https://github.com/La0/garmin-uploader for uploading.